### PR TITLE
Refactor: Drizzle 스키마 정의에서 불필요한 문자열 인자 제거

### DIFF
--- a/app/_entities/blogs/blog-settings.table.ts
+++ b/app/_entities/blogs/blog-settings.table.ts
@@ -4,21 +4,21 @@ import { blogTable } from './blogs.table';
 
 export const blogSettingTable = pgTable('blog_settings', {
   // 설정 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 ID (FK)
-  blog_id: uuid('blog_id')
+  blog_id: uuid()
     .notNull()
     .references(() => blogTable.id, { onDelete: 'cascade', }),
 
   // 설정 키
-  key: varchar('key').notNull(),
+  key: varchar().notNull(),
 
   // 설정 값
-  value: text('value'),
+  value: text(),
 
   // 마지막 수정일
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),

--- a/app/_entities/blogs/blogs.table.ts
+++ b/app/_entities/blogs/blogs.table.ts
@@ -14,37 +14,37 @@ export const blogVisibilityEnum = pgEnum('blog_visibility', [ 'PUBLIC', 'PRIVATE
 
 export const blogTable = pgTable('blogs', {
   // 블로그 고유 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 주인 ID (FK, users.id)
-  user_id: uuid('user_id')
+  user_id: uuid()
     .notNull()
     .references(() => userTable.id, { onDelete: 'cascade', }),
 
   // 블로그 이름
-  name: varchar('name').notNull(),
+  name: varchar().notNull(),
 
   // URL용 고유 슬러그
-  slug: varchar('slug').notNull().unique(),
+  slug: varchar().notNull().unique(),
 
   // 블로그 설명
-  description: text('description'),
+  description: text(),
 
   // PUBLIC 또는 PRIVATE
-  visibility: blogVisibilityEnum('visibility').default('PUBLIC'),
+  visibility: blogVisibilityEnum().default('PUBLIC'),
 
   // JSON 형태의 커스텀 설정
-  settings: jsonb('settings'),
+  settings: jsonb(),
 
   // 생성일
-  created_at: timestamp('created_at').defaultNow().notNull(),
+  created_at: timestamp().defaultNow().notNull(),
 
   // 수정일
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
   // 삭제된 시각 (Soft Delete용)
-  deleted_at: timestamp('deleted_at'),
+  deleted_at: timestamp(),
 });

--- a/app/_entities/categories/categories.table.ts
+++ b/app/_entities/categories/categories.table.ts
@@ -13,15 +13,15 @@ export const categoryTable = pgTable(
   'categories',
   {
     // 카테고리 ID (UUID, PK)
-    id: uuid('id').primaryKey().defaultRandom(),
+    id: uuid().primaryKey().defaultRandom(),
 
     // 블로그 ID (FK)
-    blog_id: uuid('blog_id')
+    blog_id: uuid()
       .notNull()
       .references(() => blogTable.id, { onDelete: 'cascade', }),
 
     // 상위 카테고리 ID (Nullable, 자기참조 FK)
-    parent_id: uuid('parent_id').references(
+    parent_id: uuid().references(
       (): AnyPgColumn => categoryTable.id,
       {
         onDelete: 'set null',
@@ -29,22 +29,22 @@ export const categoryTable = pgTable(
     ),
 
     // 카테고리 이름 (`blog_id`, `parent_id`와 함께 UNIQUE)
-    name: varchar('name').notNull(),
+    name: varchar().notNull(),
 
     // 카테고리 슬러그 (`blog_id`와 함께 UNIQUE)
-    slug: varchar('slug').notNull(),
+    slug: varchar().notNull(),
 
     // 생성일
-    created_at: timestamp('created_at').defaultNow().notNull(),
+    created_at: timestamp().defaultNow().notNull(),
 
     // 수정일
-    updated_at: timestamp('updated_at')
+    updated_at: timestamp()
       .defaultNow()
       .notNull()
       .$onUpdate(() => new Date()),
 
     // 삭제된 시각 (Soft Delete용)
-    deleted_at: timestamp('deleted_at'),
+    deleted_at: timestamp(),
   },
   (table) => {
     return {

--- a/app/_entities/comments/comments.table.ts
+++ b/app/_entities/comments/comments.table.ts
@@ -23,50 +23,50 @@ export const commentStatusEnum = pgEnum('comment_status', [
 
 export const commentTable = pgTable('comments', {
   // 댓글 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 ID (FK)
-  blog_id: uuid('blog_id')
+  blog_id: uuid()
     .notNull()
     .references(() => blogTable.id, { onDelete: 'cascade', }),
 
   // 포스트 ID (FK)
-  post_id: uuid('post_id')
+  post_id: uuid()
     .notNull()
     .references(() => postTable.id, { onDelete: 'cascade', }),
 
   // 부모 댓글 ID (Nullable, FK)
-  parent_id: uuid('parent_id').references((): AnyPgColumn => commentTable.id, {
+  parent_id: uuid().references((): AnyPgColumn => commentTable.id, {
     onDelete: 'set null',
   }),
 
   // ADMIN, VISITOR
-  author_type: commentAuthorTypeEnum('author_type').default('VISITOR'),
+  author_type: commentAuthorTypeEnum().default('VISITOR'),
 
   // PENDING, APPROVED, SPAM
-  status: commentStatusEnum('status').default('PENDING'),
+  status: commentStatusEnum().default('PENDING'),
 
   // 댓글 내용
-  content: text('content').notNull(),
+  content: text().notNull(),
 
   // 방문자 이름
-  visitor_name: varchar('visitor_name'),
+  visitor_name: varchar(),
 
   // 방문자 이메일
-  visitor_email: varchar('visitor_email'),
+  visitor_email: varchar(),
 
   // 비밀번호 (해시 처리)
-  visitor_hashed_password: varchar('visitor_hashed_password'),
+  visitor_hashed_password: varchar(),
 
   // 작성일
-  created_at: timestamp('created_at').defaultNow().notNull(),
+  created_at: timestamp().defaultNow().notNull(),
 
   // 수정일
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
   // 삭제된 시각 (Soft Delete용)
-  deleted_at: timestamp('deleted_at'),
+  deleted_at: timestamp(),
 });

--- a/app/_entities/common/announcements.table.ts
+++ b/app/_entities/common/announcements.table.ts
@@ -11,31 +11,31 @@ import { blogTable } from '../blogs/blogs.table';
 
 export const announcementTable = pgTable('announcements', {
   // 공지 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 ID (FK)
-  blog_id: uuid('blog_id')
+  blog_id: uuid()
     .notNull()
     .references(() => blogTable.id, { onDelete: 'cascade', }),
 
   // 공지 제목
-  title: varchar('title').notNull(),
+  title: varchar().notNull(),
 
   // 공지 내용
-  content: text('content').notNull(),
+  content: text().notNull(),
 
   // 상단 고정 여부
-  is_pinned: boolean('is_pinned').default(false),
+  is_pinned: boolean().default(false),
 
   // 생성일
-  created_at: timestamp('created_at').defaultNow().notNull(),
+  created_at: timestamp().defaultNow().notNull(),
 
   // 수정일
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
   // 삭제된 시각 (Soft Delete용)
-  deleted_at: timestamp('deleted_at'),
+  deleted_at: timestamp(),
 });

--- a/app/_entities/likes/post-likes.table.ts
+++ b/app/_entities/likes/post-likes.table.ts
@@ -5,21 +5,21 @@ import { postTable } from '../posts/posts.table';
 
 export const likeTable = pgTable('post_likes', {
   // 좋아요 기록 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 ID (FK)
-  blog_id: uuid('blog_id')
+  blog_id: uuid()
     .notNull()
     .references(() => blogTable.id, { onDelete: 'cascade', }),
 
   // 포스트 ID (FK)
-  post_id: uuid('post_id')
+  post_id: uuid()
     .notNull()
     .references(() => postTable.id, { onDelete: 'cascade', }),
 
   // 고유 방문자 식별자
-  visitor_id: uuid('visitor_id').notNull(),
+  visitor_id: uuid().notNull(),
 
   // 좋아요 시각
-  liked_at: timestamp('liked_at').defaultNow().notNull(),
+  liked_at: timestamp().defaultNow().notNull(),
 });

--- a/app/_entities/posts/post-revisions.table.ts
+++ b/app/_entities/posts/post-revisions.table.ts
@@ -4,19 +4,19 @@ import { postTable } from './posts.table';
 
 export const postRevisionTable = pgTable('post_revisions', {
   // 리비전 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 대상 포스트 ID (FK)
-  post_id: uuid('post_id')
+  post_id: uuid()
     .notNull()
     .references(() => postTable.id, { onDelete: 'cascade', }),
 
   // 수정 당시 제목
-  title: varchar('title').notNull(),
+  title: varchar().notNull(),
 
   // 수정 당시 내용
-  content: text('content'),
+  content: text(),
 
   // 이력 생성 시각
-  updated_at: timestamp('updated_at').defaultNow().notNull(),
+  updated_at: timestamp().defaultNow().notNull(),
 });

--- a/app/_entities/posts/post-tags.table.ts
+++ b/app/_entities/posts/post-tags.table.ts
@@ -8,11 +8,11 @@ export const postTagTable = pgTable(
   'post_tags',
   {
     // 포스트 ID (FK)
-    post_id: uuid('post_id')
+    post_id: uuid()
       .notNull()
       .references(() => postTable.id, { onDelete: 'cascade', }),
     // 태그 ID (FK)
-    tag_id: uuid('tag_id')
+    tag_id: uuid()
       .notNull()
       .references(() => tagTable.id, { onDelete: 'cascade', }),
   },

--- a/app/_entities/posts/posts.table.ts
+++ b/app/_entities/posts/posts.table.ts
@@ -28,71 +28,71 @@ export const postTable = pgTable(
   'posts',
   {
     // 포스트 ID (UUID, PK)
-    id: uuid('id').primaryKey().defaultRandom(),
+    id: uuid().primaryKey().defaultRandom(),
 
     // 소속 블로그 ID (FK)
-    blog_id: uuid('blog_id')
+    blog_id: uuid()
       .notNull()
       .references(() => blogTable.id, { onDelete: 'cascade', }),
 
     // 소속 카테고리 ID (Nullable, FK)
-    category_id: uuid('category_id').references(() => categoryTable.id, {
+    category_id: uuid().references(() => categoryTable.id, {
       onDelete: 'set null',
     }),
 
     // 포스트 제목
-    title: varchar('title').notNull(),
+    title: varchar().notNull(),
 
     // 블로그 내 고유 슬러그 (`blog_id`와 함께 UNIQUE)
-    slug: varchar('slug').notNull(),
+    slug: varchar().notNull(),
 
     // 본문 내용 (MD or HTML)
-    content: text('content'),
+    content: text(),
 
     // 요약문
-    excerpt: text('excerpt'),
+    excerpt: text(),
 
     // 썸네일 이미지 주소
-    thumbnail_url: varchar('thumbnail_url'),
+    thumbnail_url: varchar(),
 
     // DRAFT, PUBLISHED, ARCHIVED
-    status: postStatusEnum('status').default('DRAFT'),
+    status: postStatusEnum().default('DRAFT'),
 
     // PUBLIC, PRIVATE, PROTECTED
-    visibility: postVisibilityEnum('visibility').default('PUBLIC'),
+    visibility: postVisibilityEnum().default('PUBLIC'),
 
     // 보호 상태일 경우 해시된 비밀번호
-    password: varchar('password'),
+    password: varchar(),
 
     // 추천 포스트 여부
-    is_featured: boolean('is_featured').default(false),
+    is_featured: boolean().default(false),
 
     // 상단 고정 여부
-    is_pinned: boolean('is_pinned').default(false),
+    is_pinned: boolean().default(false),
 
     // 조회수 (캐시용)
-    view_count: integer('view_count').default(0),
+    view_count: integer().default(0),
 
     // 좋아요 수 (캐시용)
-    like_count: integer('like_count').default(0),
+    like_count: integer().default(0),
 
     // 언어 정보 (ko-KR 등)
-    locale: varchar('locale').default('ko-KR'),
+    locale: varchar().default('ko-KR'),
 
     // 발행일
-    published_at: timestamp('published_at'),
+    published_at: timestamp(),
 
     // 생성일
-    created_at: timestamp('created_at').defaultNow().notNull(),
+    created_at: timestamp().defaultNow().notNull(),
 
     // 수정일
-    updated_at: timestamp('updated_at')
+    updated_at: timestamp()
       .defaultNow()
       .notNull()
       .$onUpdate(() => new Date()),
 
     // 삭제된 시각 (Soft Delete용)
-    deleted_at: timestamp('deleted_at'),
+    deleted_at: timestamp(),
   },
   (table) => {
     return {

--- a/app/_entities/tags/tags.table.ts
+++ b/app/_entities/tags/tags.table.ts
@@ -13,24 +13,24 @@ export const tagTable = pgTable(
   'tags',
   {
     // 태그 ID (UUID, PK)
-    id: uuid('id').primaryKey().defaultRandom(),
+    id: uuid().primaryKey().defaultRandom(),
 
     // 블로그 ID (FK)
-    blog_id: uuid('blog_id')
+    blog_id: uuid()
       .notNull()
       .references(() => blogTable.id, { onDelete: 'cascade', }),
 
     // 태그 이름 (`blog_id`와 함께 UNIQUE)
-    name: varchar('name').notNull(),
+    name: varchar().notNull(),
 
     // 대표 태그 여부
-    is_featured: boolean('is_featured').default(false),
+    is_featured: boolean().default(false),
 
     // 생성일
-    created_at: timestamp('created_at').defaultNow().notNull(),
+    created_at: timestamp().defaultNow().notNull(),
 
     // 삭제된 시각 (Soft Delete용)
-    deleted_at: timestamp('deleted_at'),
+    deleted_at: timestamp(),
   },
   (table) => {
     return {

--- a/app/_entities/users/user-auths.table.ts
+++ b/app/_entities/users/user-auths.table.ts
@@ -4,29 +4,29 @@ import { userTable } from './users.table';
 
 export const userAuthTable = pgTable('user_auths', {
   // 인증 정보 ID (UUID, PK, 자동 생성)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // users.id 참조 (FK, UNIQUE, NOT NULL, ON DELETE CASCADE)
-  user_id: uuid('user_id')
+  user_id: uuid()
     .notNull()
     .unique()
     .references(() => userTable.id, { onDelete: 'cascade', }),
 
   // 해시된 비밀번호
-  hashed_password: varchar('hashed_password'),
+  hashed_password: varchar(),
 
   // 리프레시 토큰
-  refresh_token: text('refresh_token'),
+  refresh_token: text(),
 
   // 생성일 (자동 생성)
-  created_at: timestamp('created_at').defaultNow().notNull(),
+  created_at: timestamp().defaultNow().notNull(),
 
   // 수정일 (자동 업데이트)
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
   // 삭제된 시각 (Soft Delete용)
-  deleted_at: timestamp('deleted_at'),
+  deleted_at: timestamp(),
 });

--- a/app/_entities/users/users.table.ts
+++ b/app/_entities/users/users.table.ts
@@ -13,41 +13,41 @@ export const userRoleEnum = pgEnum('user_role', [ 'SUPER_ADMIN', 'ADMIN', 'USER'
 
 export const userTable = pgTable('users', {
   // 사용자 고유 ID (UUID, PK, 자동 생성)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 로그인용 이메일 (UNIQUE, NOT NULL)
-  email: varchar('email').notNull().unique(),
+  email: varchar().notNull().unique(),
 
   // 사용자 이름 (NOT NULL)
-  username: varchar('username').notNull(),
+  username: varchar().notNull(),
 
   // 프로필 이미지 URL
-  image: varchar('image'),
+  image: varchar(),
 
   // 관리자 소개글
-  bio: text('bio'),
+  bio: text(),
 
   // 소셜 미디어 프로필 링크 (JSON)
-  social_links: jsonb('social_links'),
+  social_links: jsonb(),
 
   // 사용자 권한 (`SUPER_ADMIN`, `ADMIN`, `USER` 중 하나, 기본값 'USER')
-  role: userRoleEnum('role').default('USER'),
+  role: userRoleEnum().default('USER'),
 
   // 계정 활성화 여부 (기본값 `true`)
-  is_active: boolean('is_active').default(true),
+  is_active: boolean().default(true),
 
   // 마지막 로그인 시각
-  last_signed_at: timestamp('last_signed_at'),
+  last_signed_at: timestamp(),
 
   // 생성일 (자동 생성)
-  created_at: timestamp('created_at').defaultNow().notNull(),
+  created_at: timestamp().defaultNow().notNull(),
 
   // 수정일 (자동 업데이트)
-  updated_at: timestamp('updated_at')
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
   // 삭제된 시각 (Soft Delete용)
-  deleted_at: timestamp('deleted_at'),
+  deleted_at: timestamp(),
 });

--- a/app/_entities/views/post-views.table.ts
+++ b/app/_entities/views/post-views.table.ts
@@ -5,24 +5,24 @@ import { postTable } from '../posts/posts.table';
 
 export const viewTable = pgTable('post_views', {
   // 조회 기록 ID (UUID, PK)
-  id: uuid('id').primaryKey().defaultRandom(),
+  id: uuid().primaryKey().defaultRandom(),
 
   // 블로그 ID (FK)
-  blog_id: uuid('blog_id')
+  blog_id: uuid()
     .notNull()
     .references(() => blogTable.id, { onDelete: 'cascade', }),
 
   // 포스트 ID (FK)
-  post_id: uuid('post_id')
+  post_id: uuid()
     .notNull()
     .references(() => postTable.id, { onDelete: 'cascade', }),
 
   // 고유 방문자 식별자 (e.g., UUID)
-  visitor_id: uuid('visitor_id').notNull(),
+  visitor_id: uuid().notNull(),
 
   // 브라우저 정보
-  user_agent: varchar('user_agent'),
+  user_agent: varchar(),
 
   // 조회 시각
-  viewed_at: timestamp('viewed_at').defaultNow().notNull(),
+  viewed_at: timestamp().defaultNow().notNull(),
 });


### PR DESCRIPTION
README.md에 정의된 스키마와 비교하여, app/_entities 폴더 내의 모든 table.ts 파일들을 다음 기준에 따라 수정했습니다:

- uuid(), varchar(), text(), timestamp(), jsonb(), boolean(), pgEnum() 등 Drizzle ORM 컬럼 정의 함수 호출 시, 컬럼명과 동일한 불필요한 문자열 인자를 제거했습니다.
- (예: uuid('id') -> uuid(), varchar('email') -> varchar())
- README.md 스키마와 비교하여 누락된 컬럼이 있는지 확인하고, 모든 파일이 최신 상태임을 확인했습니다 (실제 누락된 경우는 없었음).
- 컬럼 타입 및 제약 조건 (예: notNull, unique, default, references)이 README와 일치하는지 확인했습니다.