### PR TITLE
Feat: 각 엔티티별 Drizzle Select 타입 및 Enum 타입 추가

### DIFF
--- a/app/_entities/blogs/blog-settings.types.ts
+++ b/app/_entities/blogs/blog-settings.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { blogSettingTable } from './blog-settings.table';
+
+export type BlogSetting = InferSelectModel<typeof blogSettingTable>;

--- a/app/_entities/blogs/blogs.types.ts
+++ b/app/_entities/blogs/blogs.types.ts
@@ -1,0 +1,6 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { blogTable, blogVisibilityEnum } from './blogs.table';
+
+export type Blog = InferSelectModel<typeof blogTable>;
+export type BlogVisibility = typeof blogVisibilityEnum.enumValues[number];

--- a/app/_entities/blogs/index.ts
+++ b/app/_entities/blogs/index.ts
@@ -1,0 +1,4 @@
+export * from './blogs.table';
+export * from './blogs.types';
+export * from './blog-settings.table';
+export * from './blog-settings.types';

--- a/app/_entities/categories/categories.types.ts
+++ b/app/_entities/categories/categories.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { categoryTable } from './categories.table';
+
+export type Category = InferSelectModel<typeof categoryTable>;

--- a/app/_entities/categories/index.ts
+++ b/app/_entities/categories/index.ts
@@ -1,0 +1,2 @@
+export * from './categories.table';
+export * from './categories.types';

--- a/app/_entities/comments/comments.types.ts
+++ b/app/_entities/comments/comments.types.ts
@@ -1,0 +1,12 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type {
+  commentTable,
+  commentAuthorTypeEnum,
+  commentStatusEnum,
+} from './comments.table';
+
+export type Comment = InferSelectModel<typeof commentTable>;
+export type CommentAuthorType =
+  typeof commentAuthorTypeEnum.enumValues[number];
+export type CommentStatus = typeof commentStatusEnum.enumValues[number];

--- a/app/_entities/comments/index.ts
+++ b/app/_entities/comments/index.ts
@@ -1,0 +1,2 @@
+export * from './comments.table';
+export * from './comments.types';

--- a/app/_entities/common/announcements.types.ts
+++ b/app/_entities/common/announcements.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { announcementTable } from './announcements.table';
+
+export type Announcement = InferSelectModel<typeof announcementTable>;

--- a/app/_entities/likes/index.ts
+++ b/app/_entities/likes/index.ts
@@ -1,0 +1,2 @@
+export * from './post-likes.table';
+export * from './post-likes.types';

--- a/app/_entities/likes/post-likes.types.ts
+++ b/app/_entities/likes/post-likes.types.ts
@@ -1,0 +1,7 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+// 테이블 파일명이 post-likes.table.ts 이고, 테이블 변수명이 likeTable 이므로
+// 타입명 일관성을 위해 PostLike 로 명명합니다.
+import type { likeTable } from './post-likes.table';
+
+export type PostLike = InferSelectModel<typeof likeTable>;

--- a/app/_entities/posts/index.ts
+++ b/app/_entities/posts/index.ts
@@ -1,0 +1,6 @@
+export * from './posts.table';
+export * from './posts.types';
+export * from './post-revisions.table';
+export * from './post-revisions.types';
+export * from './post-tags.table';
+export * from './post-tags.types';

--- a/app/_entities/posts/post-revisions.types.ts
+++ b/app/_entities/posts/post-revisions.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { postRevisionTable } from './post-revisions.table';
+
+export type PostRevision = InferSelectModel<typeof postRevisionTable>;

--- a/app/_entities/posts/post-tags.types.ts
+++ b/app/_entities/posts/post-tags.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { postTagTable } from './post-tags.table';
+
+export type PostTag = InferSelectModel<typeof postTagTable>;

--- a/app/_entities/posts/posts.types.ts
+++ b/app/_entities/posts/posts.types.ts
@@ -1,0 +1,11 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type {
+  postTable,
+  postStatusEnum,
+  postVisibilityEnum,
+} from './posts.table';
+
+export type Post = InferSelectModel<typeof postTable>;
+export type PostStatus = typeof postStatusEnum.enumValues[number];
+export type PostVisibility = typeof postVisibilityEnum.enumValues[number];

--- a/app/_entities/tags/index.ts
+++ b/app/_entities/tags/index.ts
@@ -1,0 +1,2 @@
+export * from './tags.table';
+export * from './tags.types';

--- a/app/_entities/tags/tags.types.ts
+++ b/app/_entities/tags/tags.types.ts
@@ -1,0 +1,5 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { tagTable } from './tags.table';
+
+export type Tag = InferSelectModel<typeof tagTable>;

--- a/app/_entities/views/index.ts
+++ b/app/_entities/views/index.ts
@@ -1,0 +1,2 @@
+export * from './post-views.table';
+export * from './post-views.types';

--- a/app/_entities/views/post-views.types.ts
+++ b/app/_entities/views/post-views.types.ts
@@ -1,0 +1,7 @@
+import type { InferSelectModel } from 'drizzle-orm';
+
+// 테이블 파일명이 post-views.table.ts 이고, 테이블 변수명이 viewTable 이므로
+// 타입명 일관성을 위해 PostView 로 명명합니다.
+import type { viewTable } from './post-views.table';
+
+export type PostView = InferSelectModel<typeof viewTable>;


### PR DESCRIPTION
각 엔티티 폴더 내에 `*.types.ts` 파일을 생성하고, `index.ts` 파일을 수정하여 다음 타입들을 정의하고 export 했습니다:

- `InferSelectModel`을 사용한 Select 타입 (예: `Blog`, `Post`, `User`)
- Enum 테이블에 대한 값 타입 (예: `BlogVisibility`, `PostStatus`)

대상 엔티티:
- blogs
- blog_settings
- posts
- post_revisions
- post_tags
- categories
- tags
- comments
- post_views (viewTable -> PostView)
- post_likes (likeTable -> PostLike)
- announcements

사용자 요청에 따라 `InferInsertModel` 타입은 생성하지 않았습니다.